### PR TITLE
Improved running time

### DIFF
--- a/bdtaunu/Makefile
+++ b/bdtaunu/Makefile
@@ -1,5 +1,5 @@
 # Unit tests
-BINARIES := bdtaunu_root2postgres
+BINARIES := bdtaunu_root2postgres benchmark
 
 # additional include and library search paths
 ROOT2POSTGRES_ROOT = ../

--- a/bdtaunu/benchmark.cc
+++ b/bdtaunu/benchmark.cc
@@ -1,0 +1,163 @@
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <set>
+#include <string>
+#include <chrono>
+#include <algorithm>
+
+#include <ColumnConfigParser.h>
+#include <TupleReader.h>
+#include <PostgresConnector.h>
+
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+
+void root2postgres(const po::variables_map &vm);
+
+int main(int argc, char **argv) {
+
+  try {
+
+    // define program options 
+    po::options_description generic("Generic options");
+    generic.add_options()
+        ("help,h", "produce help message")
+    ;
+
+    po::options_description config("Configuration options");
+    config.add_options()
+
+        ("postgres_dbname", po::value<std::string>(), "Postgres database name. ")
+        ("postgres_tblname", po::value<std::string>(), "Postgres table name. ")
+
+        ("cernroot_fname", po::value<std::string>(), "ROOT file name. ")
+        ("cernroot_trname", po::value<std::string>()->default_value("ntp1"), "ROOT TTree name. ")
+
+        ("column_spec_fname", po::value<std::string>(), "Column configuration file. ")
+
+        ("run", po::value<std::string>(), "Run number (1-6) ")
+        ("mode_label", po::value<std::string>(), "SP mode for MC, on/offpeak for data. ")
+    ;
+
+    po::options_description hidden("Hidden options");
+    hidden.add_options()
+        ("config_file", po::value<std::string>(), "Job configuration file name. ")
+    ;
+
+    po::options_description cmdline_options;
+    cmdline_options.add(generic).add(config).add(hidden);
+
+    po::options_description config_file_options;
+    config_file_options.add(config);
+
+    po::options_description visible;
+    visible.add(generic).add(config);
+
+    po::positional_options_description p;
+    p.add("config_file", -1);
+
+    // parse program options and configuration file
+    po::variables_map vm;
+    store(po::command_line_parser(argc, argv).
+          options(cmdline_options).positional(p).run(), vm);
+    notify(vm);
+
+    if (vm.count("help") || !vm.count("config_file")) {
+      std::cout << std::endl;
+      std::cout << "Usage: root2postgres [options] config_fname" << std::endl;
+      std::cout << visible << "\n";
+      return 0;
+    }
+
+    std::ifstream fin(vm["config_file"].as<std::string>());
+    if (!fin) {
+      std::cout << "cannot open config file: ";
+      std::cout << vm["config_file"].as<std::string>() << std::endl;
+      return 0;
+    }
+
+    store(parse_config_file(fin, config_file_options), vm);
+    notify(vm);
+
+    // main routine
+    std::chrono::time_point<std::chrono::system_clock> start, end;
+    start = std::chrono::system_clock::now();
+    root2postgres(vm);
+    end = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsed_seconds = end-start;
+    std::cout << "Elapsed time: " << elapsed_seconds.count() << "s\n";
+
+  } catch(std::exception& e) {
+
+    std::cerr << "error: " << e.what() << "\n";
+    return 1;
+
+  } catch(...) {
+
+    std::cerr << "Exception of unknown type!\n";
+    return 1;
+  }
+
+
+  return 0;
+}
+
+
+void root2postgres(const po::variables_map &vm) {
+
+  // read configuration file parameters
+  std::string postgres_dbname = vm["postgres_dbname"].as<std::string>();
+  std::string postgres_tblname = vm["postgres_tblname"].as<std::string>();
+  std::string cernroot_fname = vm["cernroot_fname"].as<std::string>();
+  std::string cernroot_trname = vm["cernroot_trname"].as<std::string>();
+  std::string column_spec_fname = vm["column_spec_fname"].as<std::string>();
+  std::string run = vm["run"].as<std::string>();
+  std::string mode_label = vm["mode_label"].as<std::string>();
+
+  // print
+  //std::cout << postgres_dbname << std::endl;
+  //std::cout << postgres_tblname << std::endl;
+  //std::cout << cernroot_fname << std::endl;
+  //std::cout << cernroot_trname << std::endl;
+
+  // parse column configuration
+  ColumnConfigParser ccp(column_spec_fname);
+  std::vector<std::string> var_names = ccp.GetVarNames();
+  std::vector<std::string> usr_var_names = {"run", 
+                                            "mode_label"};
+
+  // open root file
+  TupleReader tuple_reader(cernroot_fname, cernroot_trname, ccp, 800);
+
+  // open postgres connection
+  std::vector<std::string> all_var_names = usr_var_names;
+  all_var_names.insert(all_var_names.end(), var_names.begin(), var_names.end());
+  PostgresConnector conn(postgres_dbname, postgres_tblname, all_var_names);
+
+  // stream over each event in the root file
+  std::cout << "Inserting " << cernroot_fname << "..." << std::endl;
+  while (tuple_reader.next_record()) {
+
+    // for each event, insert all variables defined in the 
+    // column spec file
+    for (const auto &v : var_names) {
+      conn.bind(v, tuple_reader.get(v));
+    }
+    conn.bind("run", run);
+    conn.bind("mode_label", mode_label);
+
+    conn.exec();
+
+    //// for each event, manually insert each column by name
+    //conn.bind("mcLen", tuple_reader.get("mcLen"));
+    //conn.bind("R2", tuple_reader.get("R2"));
+    //conn.bind("mcLund", tuple_reader.get("mcLund"));
+    //conn.bind("mcenergycm", tuple_reader.get("mcenergycm"));
+    //conn.exec();
+  }
+
+  return;
+
+}

--- a/include/PostgresConnector.h
+++ b/include/PostgresConnector.h
@@ -30,7 +30,7 @@ public:
 
   // The bind function stores the value of the variable
   // in a vector.
-  void bind(std::string var_name, std::string var_value);
+  void bind(const std::string &var_name, const std::string &var_value);
 
   // The exec function performs the insertion of the 
   // variable values that were bound by the bind function

--- a/src/PostgresConnector.cc
+++ b/src/PostgresConnector.cc
@@ -77,12 +77,12 @@ PostgresConnector::~PostgresConnector(){
 
 // The bind method puts the value of the variable into the correct index
 // in the param_values_vector_ to be pointed at by param_values_ later
-void PostgresConnector::bind(string var_name, string var_value) {
+void PostgresConnector::bind(const string &var_name, const string &var_value) {
 
   // Look for the var_name and get its index
   var_position_iter_ = std::lower_bound(var_names_.begin(), var_names_.end(), var_name);
   if ((var_position_iter_ != var_names_.end()) && 
-      (*var_position_iter_ == var_name)) {
+      !(var_name < *var_position_iter_)) {
     var_idx_ = var_position_iter_ - var_names_.begin();
   }
   else {


### PR DESCRIPTION
I added a benchmarking script bdtaunu/benchmark.cc
I've made some changes suggested by Dan, and when running only bind() commands without exec(), the run time decreased from ~70s to ~14s.

I run the benchmark.cc using the following command:

`/nfs/home/jkim/Analysis/root2postgres/bdtaunu/benchmark
--cernroot_fname /home/jkim/raid13/ntp/sp11444r1/root/8.root 
--run 1 --mode_label 11444 
/nfs/home/jkim/Analysis/root2postgres/bdtaunu/bdtaunu.cfg`

exec() call still takes around 80s so that could be improved.
